### PR TITLE
#142: Attributes->offsetGet() should return by value, not by reference.

### DIFF
--- a/atomium/includes/classes/Attributes.php
+++ b/atomium/includes/classes/Attributes.php
@@ -53,7 +53,7 @@ class Attributes implements \ArrayAccess, \IteratorAggregate {
   /**
    * {@inheritdoc}
    */
-  public function &offsetGet($name) {
+  public function offsetGet($name) {
     $return = $this->setStorage(
       $this->getStorage() + array($name => array())
     )->toArray();


### PR DESCRIPTION
@drupol I mentioned this on hangouts before..
Is there something that would break if we change it?