### PR TITLE
#155: Optimize atomium_theme_registry_alter()

### DIFF
--- a/atomium/includes/common.inc
+++ b/atomium/includes/common.inc
@@ -587,8 +587,8 @@ function atomium_get_settings($setting_keys, $base_themes = TRUE, array $value_c
  *   The base hook.
  */
 function atomium_get_base_hook($hook) {
-  while ($pos = strrpos($hook, '__')) {
-    $hook = drupal_substr($hook, 0, $pos);
+  if ($pos = strpos($hook, '__')) {
+    return drupal_substr($hook, 0, $pos);
   }
 
   return $hook;

--- a/atomium/includes/common.inc
+++ b/atomium/includes/common.inc
@@ -202,9 +202,12 @@ function &_atomium_get_attributes(array &$element, $property = 'attributes') {
 }
 
 /**
- * Discover templates based on directory name.
+ * Discovers template directories in the active theme and its base themes.
  *
  * It is important that directories have the name of the hook for the moment.
+ *
+ * @return array[][]
+ *   Format: $[$theme][$subdir_name] = ['theme' => $theme, 'directory' => $directory]
  */
 function atomium_find_templates() {
   $templates = array();

--- a/atomium/includes/common.inc
+++ b/atomium/includes/common.inc
@@ -215,8 +215,10 @@ function atomium_find_templates() {
   foreach (_atomium_get_base_themes(NULL, TRUE) as $theme) {
     $path = drupal_get_path('theme', $theme) . '/templates';
     if (is_dir($path)) {
-      $directories = array_diff(scandir($path), array('..', '.'));
-      foreach ($directories as $directory) {
+      foreach (scandir($path, SCANDIR_SORT_ASCENDING) as $directory) {
+        if ('.' === $directory[0]) {
+          continue;
+        }
         $templates[$theme][$directory] = array(
           'theme' => $theme,
           'directory' => $path . '/' . $directory,

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -57,6 +57,8 @@ function _atomium_theme(array &$existing, $type, $theme, $path) {
 
 /**
  * Implements hook_theme_registry_alter().
+ *
+ * @param array $registry
  */
 function atomium_theme_registry_alter(array &$registry) {
   $components = array();

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -77,10 +77,6 @@ function atomium_theme_registry_alter(array &$registry) {
   }
 
   array_walk($registry, function (array &$info, $hook) use ($components) {
-    // Make sure there is a preprocess for each hook.
-    $info += array(
-      'preprocess functions' => array(),
-    );
 
     if ($pos = strpos($hook, '__')) {
       $base_hook = drupal_substr($hook, 0, $pos);
@@ -108,13 +104,19 @@ function atomium_theme_registry_alter(array &$registry) {
       }
     }
 
-    foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
-      unset($info['preprocess functions'][$index]);
+    if (!empty($info['preprocess functions'])) {
+      foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
+        unset($info['preprocess functions'][$index]);
+      }
+      // The simple preprocess was not used here because theme hooks defined with
+      // a function doesn't trigger all the preprocess callbacks.
+      // It's added at the first place so we make sure it's creating the variables
+      // for hooks defined by templates and functions properly.
+      array_unshift($info['preprocess functions'], 'atomium_preprocess');
     }
-    // The simple preprocess was not used here because theme hooks defined with
-    // a function doesn't trigger all the preprocess callbacks.
-    // It's added at the first place so we make sure it's creating the variables
-    // for hooks defined by templates and functions properly.
-    array_unshift($info['preprocess functions'], 'atomium_preprocess');
+    else{
+      // $info has no preprocess functions.
+      $info['preprocess functions'] = ['atomium_preprocess'];
+    }
   });
 }

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -80,7 +80,6 @@ function atomium_theme_registry_alter(array &$registry) {
     // Make sure there is a preprocess for each hook.
     $info += array(
       'preprocess functions' => array(),
-      'includes' => array(),
     );
 
     if ($pos = strpos($hook, '__')) {
@@ -91,23 +90,27 @@ function atomium_theme_registry_alter(array &$registry) {
     }
 
     if (isset($components[$base_hook])) {
-      $info['includes'] = array_unique(
-        array_merge(
-          $info['includes'],
-          $components[$base_hook]
-        )
-      );
+      if (!empty($info['includes'])) {
+        $info['includes'] = array_unique(
+          array_merge(
+            $info['includes'],
+            $components[$base_hook]));
+      }
+      else {
+        $info['includes'] = $components[$base_hook];
+      }
     }
     else {
-      // To achieve complete BC with previous versions of Atomium,
-      // array_unique() must be called here.
-      $info['includes'] = array_unique($info['includes']);
+      if (!empty($info['includes'])) {
+        // To achieve complete BC with previous versions of Atomium,
+        // array_unique() must be called here.
+        $info['includes'] = array_unique($info['includes']);
+      }
     }
 
     foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
       unset($info['preprocess functions'][$index]);
     }
-
     // The simple preprocess was not used here because theme hooks defined with
     // a function doesn't trigger all the preprocess callbacks.
     // It's added at the first place so we make sure it's creating the variables

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -104,13 +104,9 @@ function atomium_theme_registry_alter(array &$registry) {
       $info['includes'] = array_unique($info['includes']);
     }
 
-    // Remove 'atomium preprocess' callback.
-    $info['preprocess functions'] = array_filter(
-      $info['preprocess functions'],
-      function ($preprocess) {
-        return 'atomium_preprocess' !== $preprocess;
-      }
-    );
+    foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
+      unset($info['preprocess functions'][$index]);
+    }
 
     // The simple preprocess was not used here because theme hooks defined with
     // a function doesn't trigger all the preprocess callbacks.

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -76,7 +76,7 @@ function atomium_theme_registry_alter(array &$registry) {
     }
   }
 
-  array_walk($registry, function (array &$info, $hook) use ($components) {
+  foreach ($registry as $hook => &$info) {
 
     if ($pos = strpos($hook, '__')) {
       $base_hook = drupal_substr($hook, 0, $pos);
@@ -118,5 +118,5 @@ function atomium_theme_registry_alter(array &$registry) {
       // $info has no preprocess functions.
       $info['preprocess functions'] = ['atomium_preprocess'];
     }
-  });
+  }
 }

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -83,7 +83,12 @@ function atomium_theme_registry_alter(array &$registry) {
       'includes' => array(),
     );
 
-    $base_hook = atomium_get_base_hook($hook);
+    if ($pos = strpos($hook, '__')) {
+      $base_hook = drupal_substr($hook, 0, $pos);
+    }
+    else {
+      $base_hook = $hook;
+    }
     $components += array($base_hook => array());
 
     $info['includes'] = array_unique(

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -63,6 +63,21 @@ function _atomium_theme(array &$existing, $type, $theme, $path) {
 function atomium_theme_registry_alter(array &$registry) {
   $components = array();
 
+  $ignorelist = atomium_get_settings('hooks_to_ignore');
+  $ignoremap = array_fill_keys($ignorelist, TRUE);
+
+  foreach ($ignoremap as $hook => $_true) {
+    if (0
+      || !isset($registry[$hook]['function'])
+      || isset($registry[$hook]['template'])
+      || 'atomium_' . $hook === $registry[$hook]['function']
+    ) {
+      unset($ignoremap[$hook]);
+      continue;
+    }
+  }
+
+
   // Prepare an array of files to include.
   /**
    * @var array[] $data
@@ -78,11 +93,24 @@ function atomium_theme_registry_alter(array &$registry) {
 
   foreach ($registry as $hook => &$info) {
 
+    $ignore = isset($ignoremap[$hook]);
+
     if ($pos = strpos($hook, '__')) {
       $base_hook = drupal_substr($hook, 0, $pos);
     }
     else {
       $base_hook = $hook;
+    }
+
+    if (isset($ignoremap[$base_hook])) {
+      if ($base_hook !== $hook) {
+        // Unset all children of ignored base hooks.
+        unset($registry[$hook]);
+      }
+      else {
+
+      }
+      continue;
     }
 
     if (isset($components[$base_hook])) {
@@ -104,19 +132,31 @@ function atomium_theme_registry_alter(array &$registry) {
       }
     }
 
-    if (!empty($info['preprocess functions'])) {
-      foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
-        unset($info['preprocess functions'][$index]);
+    if (!$ignore) {
+      if (!empty($info['preprocess functions'])) {
+        foreach (array_keys($info['preprocess functions'], 'atomium_preprocess') as $index) {
+          unset($info['preprocess functions'][$index]);
+        }
+        // The simple preprocess was not used here because theme hooks defined with
+        // a function doesn't trigger all the preprocess callbacks.
+        // It's added at the first place so we make sure it's creating the variables
+        // for hooks defined by templates and functions properly.
+        array_unshift($info['preprocess functions'], 'atomium_preprocess');
       }
-      // The simple preprocess was not used here because theme hooks defined with
-      // a function doesn't trigger all the preprocess callbacks.
-      // It's added at the first place so we make sure it's creating the variables
-      // for hooks defined by templates and functions properly.
-      array_unshift($info['preprocess functions'], 'atomium_preprocess');
+      else{
+        // $info has no preprocess functions.
+        $info['preprocess functions'] = ['atomium_preprocess'];
+      }
     }
-    else{
-      // $info has no preprocess functions.
-      $info['preprocess functions'] = ['atomium_preprocess'];
+    else {
+      foreach (['preprocess functions', 'process functions'] as $phase => $phase_key) {
+        foreach (preg_grep('@^atomium_' . $phase . '(?:$|_)@', $info[$phase_key]) as $i => $function) {
+          unset($info[$phase_key][$i]);
+        }
+        if ([] === $info[$phase_key]) {
+          unset($info[$phase_key]);
+        }
+      }
     }
   }
 }

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -89,14 +89,20 @@ function atomium_theme_registry_alter(array &$registry) {
     else {
       $base_hook = $hook;
     }
-    $components += array($base_hook => array());
 
-    $info['includes'] = array_unique(
-      array_merge(
-        $info['includes'],
-        $components[$base_hook]
-      )
-    );
+    if (isset($components[$base_hook])) {
+      $info['includes'] = array_unique(
+        array_merge(
+          $info['includes'],
+          $components[$base_hook]
+        )
+      );
+    }
+    else {
+      // To achieve complete BC with previous versions of Atomium,
+      // array_unique() must be called here.
+      $info['includes'] = array_unique($info['includes']);
+    }
 
     // Remove 'atomium preprocess' callback.
     $info['preprocess functions'] = array_filter(

--- a/atomium/includes/registry.inc
+++ b/atomium/includes/registry.inc
@@ -64,6 +64,10 @@ function atomium_theme_registry_alter(array &$registry) {
   $components = array();
 
   // Prepare an array of files to include.
+  /**
+   * @var array[] $data
+   *   Format: $[$subdir_name] = ['theme' => $theme, 'directory' => $directory]
+   */
   foreach (atomium_find_templates() as $data) {
     foreach ($data as $component_name => $component_info) {
       foreach (glob($component_info['directory'] . '/*.component.inc') as $filename) {

--- a/atomium_bartik/atomium_bartik.info
+++ b/atomium_bartik/atomium_bartik.info
@@ -92,3 +92,5 @@ settings[alter][css_alter][exclude][] = 'modules/taxonomy/taxonomy.css'
 settings[alter][css_alter][exclude][] = 'modules/tracker/tracker.css'
 settings[alter][css_alter][exclude][] = 'modules/update/update.css'
 settings[alter][css_alter][exclude][] = 'modules/user/user.css'
+
+settings[hooks_to_ignore][] = atomiumprofiler_example_minimal


### PR DESCRIPTION
@drupol Do not merge yet! This branch contains some "preview" junk.

I measured this and got measurable improvement for almost every optimization step.

Overall:
before: 1.9140625
after: 1.1630859375

for this specific function.

Measured via a hack in drupal_alter():

```diff
diff --git a/includes/module.inc b/includes/module.inc
index 4c2b3fb..f1d6830 100644
--- a/includes/module.inc
+++ b/includes/module.inc
@@ -1168,6 +1168,21 @@ function drupal_alter($type, &$data, &$context1 = NULL, &$context2 = NULL, &$con
   }
   foreach ($functions[$cid] as $function) {
-    $function($data, $context1, $context2, $context3);
+    if ('atomium_theme_registry_alter' === $function) {
+      $data_before = $data;
+      $dtsMs = [];
+      for ($i = 0; $i < 10; ++$i) {
+        $data = $data_before;
+        $t0Ms = microtime(TRUE) * 1000;
+        $function($data, $context1, $context2, $context3);
+        $t1Ms = microtime(TRUE) * 1000;
+        $dtsMs[] = $t1Ms - $t0Ms;
+      }
+      sort($dtsMs);
+      dpm($dtsMs[0], __FUNCTION__ . '() calling ' . $function . '()');
+    }
+    else {
+      $function($data, $context1, $context2, $context3);
+    }
   }
 }
```