### PR TITLE
Issue #143: 7.x-2.x: Optimize atomium_get_settings()

### DIFF
--- a/atomium/includes/common.inc
+++ b/atomium/includes/common.inc
@@ -666,41 +666,126 @@ function _atomium_array_flatten(array $array, array &$storage, $parentKey = '') 
  *   The settings as an array.
  */
 function atomium_get_settings($setting_keys, $base_themes = TRUE, array $value_callbacks = array('trim')) {
-  static $settings_by_theme = [];
   $theme_key = $GLOBALS['theme_key'];
+  $settings_flat_filtered = _atomium_get_settings_flat_filtered($theme_key, $base_themes, $value_callbacks);
+
+  return isset($settings_flat_filtered[$setting_keys])
+    ? $settings_flat_filtered[$setting_keys]
+    : [];
+}
+
+/**
+ * @param string $theme_key
+ * @param bool $base_themes
+ * @param callable[] $value_callbacks
+ *
+ * @return mixed
+ */
+function _atomium_get_settings_flat_filtered($theme_key, $base_themes = TRUE, $value_callbacks = ['trim']) {
+  static $settings_flat_filtered_by_cid = [];
   $cid = $theme_key;
   if ($base_themes) {
-    $cid .= '+';
+    $cid .= '(b)';
+  }
+  if ([] === $value_callbacks) {
+    $trim = FALSE;
+  }
+  elseif (['trim'] === $value_callbacks) {
+    $trim = TRUE;
+    $cid .= '(t)';
+  }
+  else {
+    // Don't cache. There could be closures in $value_callbacks.
+    $trim = NULL;
+    $cid = NULL;
   }
 
-  if (!isset($settings_by_theme[$cid])) {
-    $settings_by_theme[$cid] = [];
-    if ($theme_settings = atomium_get_theme_info($theme_key, 'settings', $base_themes)) {
-      _atomium_array_flatten(
-        $theme_settings,
-        $settings_by_theme[$cid]);
-    }
+  if (NULL !== $cid && isset($settings_flat_filtered_by_cid[$cid])) {
+    return $settings_flat_filtered_by_cid[$cid];
   }
 
-  $settings = $settings_by_theme[$cid];
+  $empty_string_value = '';
+  $empty_string_value_empty = TRUE;
+  if (NULL === $trim) {
+    // Let's see what our value callbacks do to the empty string.
+    foreach ($value_callbacks as $value_callback) {
+      $empty_string_value = $value_callback($empty_string_value);
+    }
+    $empty_string_value_empty = empty($empty_string_value);
+  }
 
-  $setting_value = array();
+  $theme_settings_flat = _atomium_get_settings_flat_unfiltered($theme_key, $base_themes);
 
-  if (isset($settings[$setting_keys])) {
-    if (is_string($settings[$setting_keys])) {
-      $setting_value = explode(',', $settings[$setting_keys]);
+
+  foreach ($theme_settings_flat as $key => &$value) {
+    if (NULL === $value) {
+      $value = [];
+      continue;
+    }
+    if ('' === $value) {
+      if ($empty_string_value_empty) {
+        $value = [];
+      }
+      else {
+        $value = [$empty_string_value];
+      }
+      continue;
+    }
+    if ([] === $value) {
+      // Leave it as is.
+      continue;
     }
 
-    if (is_array($settings[$setting_keys])) {
-      $setting_value = $settings[$setting_keys];
+    if (is_string($value)) {
+      $value = explode(',', $value);
+    }
+    elseif (is_array($value)) {
+      // Leave as is.
+    }
+    else {
+      $value = [];
+      continue;
     }
 
     foreach ($value_callbacks as $value_callback) {
-      $setting_value = array_map($value_callback, $setting_value);
+      $value = array_map($value_callback, $value);
     }
+
+    $value = array_values(array_filter($value));
   }
 
-  return array_values(array_filter($setting_value));
+  if (NULL !== $cid) {
+    $settings_flat_filtered_by_cid[$cid] = $theme_settings_flat;
+  }
+
+  return $theme_settings_flat;
+}
+
+/**
+ * @param string $theme_key
+ * @param bool $base_themes
+ *
+ * @return array|mixed
+ */
+function _atomium_get_settings_flat_unfiltered($theme_key, $base_themes = TRUE) {
+  static $settings_flat_by_cid = [];
+  $cid = $theme_key;
+  if ($base_themes) {
+    $cid .= '(b)';
+  }
+  if (isset($settings_flat_by_cid[$cid])) {
+    return $settings_flat_by_cid[$cid];
+  }
+  if (!$theme_settings = atomium_get_theme_info($theme_key, 'settings', $base_themes)) {
+    return $settings_flat_by_cid[$cid] = [];
+  }
+
+  $theme_settings_flat = [];
+  _atomium_array_flatten(
+    $theme_settings,
+    $theme_settings_flat);
+
+  return $settings_flat_by_cid[$cid] = $theme_settings_flat;
 }
 
 /**

--- a/atomium/includes/common.inc
+++ b/atomium/includes/common.inc
@@ -666,16 +666,23 @@ function _atomium_array_flatten(array $array, array &$storage, $parentKey = '') 
  *   The settings as an array.
  */
 function atomium_get_settings($setting_keys, $base_themes = TRUE, array $value_callbacks = array('trim')) {
+  static $settings_by_theme = [];
   $theme_key = $GLOBALS['theme_key'];
-
-  $settings = array();
-
-  if ($theme_settings = atomium_get_theme_info($theme_key, 'settings', $base_themes)) {
-    _atomium_array_flatten(
-      $theme_settings,
-      $settings
-    );
+  $cid = $theme_key;
+  if ($base_themes) {
+    $cid .= '+';
   }
+
+  if (!isset($settings_by_theme[$cid])) {
+    $settings_by_theme[$cid] = [];
+    if ($theme_settings = atomium_get_theme_info($theme_key, 'settings', $base_themes)) {
+      _atomium_array_flatten(
+        $theme_settings,
+        $settings_by_theme[$cid]);
+    }
+  }
+
+  $settings = $settings_by_theme[$cid];
 
   $setting_value = array();
 


### PR DESCRIPTION
Fixes #143.

This is a backport for 7.x-2.x based on the first two commits in https://github.com/ec-europa/atomium/pull/147.

If my profiling is correct:
- The first two commits of the other PR each bring a clear performance improvement.
- The 3rd commit of the other PR provides only a negligible improvement, but has a risk of BC breakage in case of setting keys containing '.' character (which is used as glue in _atomium_array_flatten()). This is why this last commit is not included here.

While the other PR was marked "WIP", with this one I am serious :)