### PR TITLE
Issue #165: (grumphp) Allow parantheses in commit message.

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -18,7 +18,7 @@ parameters:
       case_insensitive: true
       multiline: true
       matchers:
-        - '/^([A-Z]+\-\d+|Issue #\d+): [A-Z].+\./'
+        - '/^([A-Z]+\-\d+|Issue #\d+): (\([^\(\)]+\) )*[A-Z].+\./'
     phpunit:
       always_execute: false
     securitychecker:


### PR DESCRIPTION
Fixes #165.

This would allow commit messages like this:

> Issue #123: (CS) Fix indentation.
> Issue #123: (testing) Generate fixtures.

This was originally part of https://github.com/ec-europa/atomium/pull/167, but I think it makes sense to merge it separately.