### PR TITLE
Issue #237: Fix Drone builds failure probably related to drupal-composer/preserve-paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "composer/installers": "^1.6",
-        "drupal-composer/preserve-paths": "^0.1",
+        "drupal-composer/preserve-paths": "dev-master#7f99622800504c058e5230b63d3cd25809fa23ba",
         "drupal/admin_menu": "3.0.0-rc6",
         "drupal/composer_autoloader": "^1",
         "drupal/devel": "^1",


### PR DESCRIPTION
Fix #237 

 - As there is an issue open on the library side, the solution is to use the commit hash till the issue get the release, currently is merged but not released.
