### PR TITLE
Issue #348: Prevent anchor name collisions when rendering the page /atomium-overview

### DIFF
--- a/atomium/templates/atomium_overview/atomium-overview.tpl.php
+++ b/atomium/templates/atomium_overview/atomium-overview.tpl.php
@@ -9,7 +9,7 @@
 <ul>
   <?php foreach ($definitions as $name => $definition): ?>
       <li>
-          <a href="#<?php print $name ?>"><?php print $definition['label'] ?></a>
+          <a href="#<?php print $name ?>-preview"><?php print $definition['label'] ?></a>
       </li>
   <?php endforeach; ?>
 </ul>
@@ -18,7 +18,7 @@
 
 <div>
   <?php foreach ($definitions as $name => $definition): ?>
-      <a name="<?php print $name ?>"></a>
+      <a name="<?php print $name ?>-preview"></a>
       <h4><?php print $definition['label'] ?></h4>
       <fieldset>
           <legend><?php print t('Preview') ?></legend>


### PR DESCRIPTION
Fix #348 